### PR TITLE
Add code coverage report generation to Alitheia core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,59 @@
           <tagBase>https://svn.sqo-oss.org/tags</tagBase>
         </configuration>
       </plugin>
+      <!-- JaCoCo configuration from http://www.petrikainulainen.net/programming/maven/creating-code-coverage-reports-for-unit-and-integration-tests-with-the-jacoco-maven-plugin/ -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.6.4.201312101107</version>
+        <executions>
+          <!--
+             Prepares the property pointing to the JaCoCo runtime agent which
+             is passed as VM argument when Maven the Surefire plugin is executed.
+          -->
+          <execution>
+            <id>pre-unit-test</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <!-- Sets the path to the file which contains the execution data. -->
+              <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
+              <!--
+                     Sets the name of the property containing the settings
+                     for JaCoCo runtime agent.
+              -->
+              <propertyName>surefireArgLine</propertyName>
+            </configuration>
+          </execution>
+          <!--
+             Ensures that the code coverage report for unit tests is created after
+             unit tests have been run.
+          -->
+          <execution>
+            <id>post-unit-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <!-- Sets the path to the file which contains the execution data. -->
+              <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
+              <!-- Sets the output directory for the code coverage report. -->
+              <outputDirectory>${project.build.directory}/coverage-reports/</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.7.1</version>
+        <configuration>
+          <!-- Sets the VM argument line used when unit tests are run. -->
+          <argLine>${surefireArgLine}</argLine>
+        </configuration>
+      </plugin>
     </plugins>
     <extensions>
         <extension>


### PR DESCRIPTION
Add code coverage generation of tests in Alitheia Core. Might be helpful to merge for others to use during test generation.

The coverage reports will be generated at the end of the `mvn test` run in the `alitheia/core/target/coverage-reports/` directory.

Note that this coverage is only being added to the `alitheia/core/pom.xml` file. This is done to quickly run tests on the core subset of alitheia without testing the rest. Is there a way to load the settings from the global `pom.xml` file?
