### PR TITLE
Force line endings to Unix-style line endings for java and scala files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.java text eol=lf diff=java
+*.scala text eol=lf


### PR DESCRIPTION
Added gitattributes to force java files to Unix-style line endings

Might cause problems with files that are currently CRLF or people who have CRLF files in their fork. Do you think it is a good idea to add this? (my git experience might be insufficient)

Also small possibility that some Windows tools don't work on LF files (solution: use better tools ;))

Sources:
https://coderwall.com/p/buf0rq
http://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/
