### PR TITLE
Implement Dependency Injection for all services using Guice.

### DIFF
--- a/alitheia/core/pom.xml
+++ b/alitheia/core/pom.xml
@@ -136,6 +136,14 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
       <version>1.2.1.GA</version>
+
+	  <exclusions>
+		<exclusion> 
+		  <groupId>org.slf4j</groupId>
+		  <artifactId>slf4j-simple</artifactId>
+		</exclusion>
+	  </exclusions> 
+
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
@@ -175,6 +183,26 @@
     	<artifactId>mockito-core</artifactId>
     	<version>1.9.5</version>
     	<scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>com.google.inject</groupId>
+    	<artifactId>guice</artifactId>
+    	<version>3.0</version>
+    </dependency>
+    <dependency>
+    	<groupId>javax.inject</groupId>
+    	<artifactId>javax.inject</artifactId>
+    	<version>1</version>
+    </dependency>
+    <dependency>
+    	<groupId>aopalliance</groupId>
+    	<artifactId>aopalliance</artifactId>
+    	<version>1.0</version>
+	</dependency>
+	<dependency>
+    	<groupId>com.google.inject.extensions</groupId>
+    	<artifactId>guice-assistedinject</artifactId>
+    	<version>3.0</version>
     </dependency>
   </dependencies>
     

--- a/alitheia/core/src/main/java/eu/sqooss/core/CoreModule.java
+++ b/alitheia/core/src/main/java/eu/sqooss/core/CoreModule.java
@@ -1,0 +1,109 @@
+package eu.sqooss.core;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+import eu.sqooss.impl.service.admin.AdminServiceImpl;
+import eu.sqooss.impl.service.cluster.ClusterNodeServiceImpl;
+import eu.sqooss.impl.service.db.DBServiceImpl;
+import eu.sqooss.impl.service.fds.FDSServiceImpl;
+import eu.sqooss.impl.service.logging.LogManagerImpl;
+import eu.sqooss.impl.service.metricactivator.MetricActivatorImpl;
+import eu.sqooss.impl.service.pa.PAServiceImpl;
+import eu.sqooss.impl.service.rest.ResteasyServiceImpl;
+import eu.sqooss.impl.service.scheduler.SchedulerServiceImpl;
+import eu.sqooss.impl.service.tds.TDSServiceImpl;
+import eu.sqooss.impl.service.updater.UpdaterServiceImpl;
+import eu.sqooss.impl.service.webadmin.WebadminServiceImpl;
+import eu.sqooss.service.admin.AdminService;
+import eu.sqooss.service.cluster.ClusterNodeService;
+import eu.sqooss.service.db.DBService;
+import eu.sqooss.service.fds.FDSService;
+import eu.sqooss.service.logging.LogManager;
+import eu.sqooss.service.metricactivator.MetricActivator;
+import eu.sqooss.service.pa.PluginAdmin;
+import eu.sqooss.service.scheduler.Scheduler;
+import eu.sqooss.service.tds.TDSService;
+import eu.sqooss.service.updater.UpdaterService;
+import eu.sqooss.service.webadmin.WebadminService;
+
+
+public class CoreModule extends AbstractModule {
+
+	@Override
+	protected void configure() {
+		bind(AdminServiceImpl.class);
+		bind(ClusterNodeServiceImpl.class);
+		bind(DBServiceImpl.class);
+		bind(FDSServiceImpl.class);
+		bind(LogManagerImpl.class);
+		bind(MetricActivatorImpl.class);
+		bind(PAServiceImpl.class);
+		bind(ResteasyServiceImpl.class);
+		bind(SchedulerServiceImpl.class);
+		bind(TDSServiceImpl.class);
+		bind(UpdaterServiceImpl.class);
+		bind(WebadminServiceImpl.class);
+	}
+
+	@Provides
+	LogManager provideLogManager() {
+		return AlitheiaCore.getInstance().getLogManager();
+	}
+
+	@Provides
+	WebadminService provideWebadminService() {
+        return AlitheiaCore.getInstance().getWebadminService();
+    }
+
+	@Provides
+	PluginAdmin providePluginAdmin() {
+		return AlitheiaCore.getInstance().getPluginAdmin();
+    }
+
+	@Provides
+	DBService provideDBService() {
+		return AlitheiaCore.getInstance().getDBService();
+    }
+
+	@Provides
+	FDSService provideFDSService() {
+		return AlitheiaCore.getInstance().getFDSService();
+    }
+
+	@Provides
+	Scheduler provideScheduler() {
+		return AlitheiaCore.getInstance().getScheduler();
+    }
+
+	@Provides
+	SecurityManager provideSecurityManager() {
+		return AlitheiaCore.getInstance().getSecurityManager();
+    }
+
+	@Provides
+	TDSService provideTDSService() {
+		return AlitheiaCore.getInstance().getTDSService();
+    }
+
+	@Provides
+	UpdaterService provideUpdater() {
+		return AlitheiaCore.getInstance().getUpdater();
+    }
+
+	@Provides
+	ClusterNodeService provideClusterNodeService() {
+		return AlitheiaCore.getInstance().getClusterNodeService();
+    }
+
+	@Provides
+	MetricActivator provideMetricActivator() {
+		return AlitheiaCore.getInstance().getMetricActivator();
+    }
+
+	@Provides
+	AdminService provideAdminService() {
+		return AlitheiaCore.getInstance().getAdminService();
+    }
+}
+

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/cluster/ClusterNodeServiceImpl.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/cluster/ClusterNodeServiceImpl.java
@@ -50,7 +50,9 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 
-import eu.sqooss.core.AlitheiaCore;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
 import eu.sqooss.service.cluster.ClusterNodeActionException;
 import eu.sqooss.service.cluster.ClusterNodeService;
 import eu.sqooss.service.db.ClusterNode;
@@ -81,15 +83,22 @@ public class ClusterNodeServiceImpl extends HttpServlet implements ClusterNodeSe
 	}
 
     private Logger logger = null;
-    private AlitheiaCore core = null;
     private HttpService httpService = null;
     private BundleContext context;
     private DBService dbs = null;
     private UpdaterService upds = null;
     
     private ClusterNode thisNode = null;
+    
+    private final Provider<DBService> dbsProvider;
+    private final Provider<UpdaterService> updateProvider;
 
-    public ClusterNodeServiceImpl() {}
+    @Inject
+    public ClusterNodeServiceImpl(Provider<DBService> dbsProvider,
+    								Provider<UpdaterService> updateProvider) {
+    	this.dbsProvider = dbsProvider;
+    	this.updateProvider = updateProvider;
+    }
     
     public String getClusterNodeName(){
 	   return thisNode.getName();
@@ -397,10 +406,9 @@ public class ClusterNodeServiceImpl extends HttpServlet implements ClusterNodeSe
 		
 		/* Get a reference to the core service*/
         ServiceReference serviceRef = null;
-      
-        core = AlitheiaCore.getInstance();
-        dbs = core.getDBService();
-        upds = core.getUpdater();
+
+        dbs = dbsProvider.get();
+        upds = updateProvider.get();
         if (logger != null) {
             logger.info("Got a valid reference to the logger");
         } else {

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/db/DBServiceImpl.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/db/DBServiceImpl.java
@@ -62,7 +62,6 @@ import org.hibernate.cfg.AnnotationConfiguration;
 import org.hibernate.cfg.Configuration;	
 import org.osgi.framework.BundleContext;
 
-import eu.sqooss.core.AlitheiaCoreService;
 import eu.sqooss.service.db.DAObject;
 import eu.sqooss.service.db.DBService;
 import eu.sqooss.service.logging.Logger;
@@ -75,7 +74,7 @@ import eu.sqooss.service.util.URIUtills;
  * @author Romain Pokrzywka, Georgios Gousios
  * 
  */
-public class DBServiceImpl implements DBService, AlitheiaCoreService {
+public class DBServiceImpl implements DBService {
 
     private static DBService instance;
     

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/FDSServiceModule.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/FDSServiceModule.java
@@ -1,0 +1,18 @@
+package eu.sqooss.impl.service.fds;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+
+import eu.sqooss.service.fds.OnDiskCheckout;
+import eu.sqooss.service.fds.Timeline;
+
+public class FDSServiceModule extends AbstractModule {
+
+	@Override
+	protected void configure() {
+		install(new FactoryModuleBuilder().implement(OnDiskCheckout.class,
+					OnDiskCheckoutImpl.class).build(OnDiskCheckoutFactory.class));
+		install(new FactoryModuleBuilder().implement(Timeline.class, 
+					TimelineImpl.class).build(TimelineFactory.class));
+	}
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/OnDiskCheckoutFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/OnDiskCheckoutFactory.java
@@ -1,0 +1,12 @@
+package eu.sqooss.impl.service.fds;
+
+import java.io.File;
+
+import eu.sqooss.service.db.ProjectVersion;
+import eu.sqooss.service.fds.OnDiskCheckout;
+import eu.sqooss.service.tds.SCMAccessor;
+
+public interface OnDiskCheckoutFactory {
+	OnDiskCheckout create(SCMAccessor accessor, String path,
+            					ProjectVersion pv, File root);
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/OnDiskCheckoutImpl.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/OnDiskCheckoutImpl.java
@@ -37,7 +37,10 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.concurrent.locks.ReentrantLock;
 
-import eu.sqooss.core.AlitheiaCore;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.assistedinject.Assisted;
+
 import eu.sqooss.service.db.DBService;
 import eu.sqooss.service.db.ProjectVersion;
 import eu.sqooss.service.fds.CheckoutException;
@@ -64,11 +67,18 @@ class OnDiskCheckoutImpl implements OnDiskCheckout {
     private ProjectVersion revision;
     private SCMAccessor scm;
     
+    private final Provider<DBService> dbsProvider;
+    
     private boolean initCheckout = false;
 
-    OnDiskCheckoutImpl(SCMAccessor accessor, String path,
-                       ProjectVersion pv, File root) {
-        repoPath = path;
+    @Inject
+    OnDiskCheckoutImpl(	Provider<DBService> dbsProviderC,
+    					@Assisted SCMAccessor accessor,
+    					@Assisted String path, 
+    					@Assisted ProjectVersion pv,
+    					@Assisted File root) {
+        dbsProvider = dbsProviderC;
+    	repoPath = path;
         localRoot = root;
         revision = pv;
         scm = accessor;
@@ -121,7 +131,7 @@ class OnDiskCheckoutImpl implements OnDiskCheckout {
     
     /** {@inheritDoc} */
     public ProjectVersion getProjectVersion() {
-        DBService dbs = AlitheiaCore.getInstance().getDBService();
+        DBService dbs = dbsProvider.get();
         revision = dbs.attachObjectToDBSession(revision);
         return revision;
     }

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/TimelineFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/TimelineFactory.java
@@ -1,0 +1,8 @@
+package eu.sqooss.impl.service.fds;
+
+import eu.sqooss.service.db.StoredProject;
+import eu.sqooss.service.fds.Timeline;
+
+public interface TimelineFactory {
+	Timeline create(StoredProject project);
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/TimelineImpl.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/fds/TimelineImpl.java
@@ -43,7 +43,10 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import eu.sqooss.core.AlitheiaCore;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.assistedinject.Assisted;
+
 import eu.sqooss.service.db.Bug;
 import eu.sqooss.service.db.DBService;
 import eu.sqooss.service.db.MailMessage;
@@ -62,10 +65,15 @@ import eu.sqooss.service.fds.Timeline;
  */
 class TimelineImpl implements Timeline {
    
+	private final Provider<DBService> dbsProvider;
+	
     private StoredProject project;
 
-    public TimelineImpl(StoredProject project) {
-        this.project = project;
+    @Inject
+    public TimelineImpl(Provider<DBService> dbsProvider,
+    					@Assisted StoredProject project) {
+        this.dbsProvider = dbsProvider;
+    	this.project = project;
     }
 
     private SortedSet<RepositoryEvent> getScmTimeLine(Calendar from, Calendar to) {
@@ -74,7 +82,7 @@ class TimelineImpl implements Timeline {
         final long begin = from.getTimeInMillis();
         final long end = to.getTimeInMillis();
         
-        DBService dbs = AlitheiaCore.getInstance().getDBService();
+        DBService dbs = dbsProvider.get();
         StringBuilder query = new StringBuilder("select pv ");
         query.append("from ProjectVersion pv ");
         query.append("where pv.timestamp < :paramTo ");
@@ -99,7 +107,7 @@ class TimelineImpl implements Timeline {
         final Date begin = from.getTime();
         final Date end = to.getTime();
         
-        DBService dbs = AlitheiaCore.getInstance().getDBService();
+        DBService dbs = dbsProvider.get();
         StringBuilder query = new StringBuilder("select mm ");
         query.append("from MailMessage mm ");
         query.append("where mm.sendDate < :paramTo ");
@@ -131,7 +139,7 @@ class TimelineImpl implements Timeline {
         final Date begin = from.getTime();
         final Date end = to.getTime();
 
-        DBService dbs = AlitheiaCore.getInstance().getDBService();
+        DBService dbs = dbsProvider.get();
         StringBuilder query = new StringBuilder("select b ");
         query.append("from Bug b ");
         query.append("where b.creationTS < :paramTo ");

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/metricactivator/MetricActivatorJob.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/metricactivator/MetricActivatorJob.java
@@ -37,7 +37,10 @@ import java.util.List;
 
 import org.hibernate.exception.LockAcquisitionException;
 
-import eu.sqooss.core.AlitheiaCore;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.assistedinject.Assisted;
+
 import eu.sqooss.service.abstractmetric.AbstractMetric;
 import eu.sqooss.service.abstractmetric.AlreadyProcessingException;
 import eu.sqooss.service.abstractmetric.MetricMismatchException;
@@ -63,15 +66,18 @@ public class MetricActivatorJob extends Job {
     Class<? extends DAObject> daoType;
     private boolean fastSync = false; 
     
-    MetricActivatorJob(AbstractMetric m, Long daoID, Logger l,
-            Class<? extends DAObject> daoType, long priority, 
-            boolean fastSync) {
+    @Inject
+    MetricActivatorJob(Provider<DBService> dbsProvider,
+    		Provider<MetricActivator> maProvider,
+    		@Assisted AbstractMetric m, @Assisted("daoID") Long daoID,
+    		@Assisted Logger l, @Assisted Class<? extends DAObject> daoType,
+    		@Assisted("priority") long priority, @Assisted boolean fastSync) {
     	this.metric = m;
         this.logger = l;
         this.daoID = daoID;
         this.daoType = daoType;
-        this.dbs = AlitheiaCore.getInstance().getDBService();
-        this.ma = AlitheiaCore.getInstance().getMetricActivator(); 
+        this.dbs = dbsProvider.get();
+        this.ma = maProvider.get(); 
         this.priority = priority;
         this.fastSync = fastSync;
     }

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/metricactivator/MetricActivatorJobFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/metricactivator/MetricActivatorJobFactory.java
@@ -1,0 +1,16 @@
+package eu.sqooss.impl.service.metricactivator;
+
+import com.google.inject.assistedinject.Assisted;
+
+import eu.sqooss.service.abstractmetric.AbstractMetric;
+import eu.sqooss.service.db.DAObject;
+import eu.sqooss.service.logging.Logger;
+
+public interface MetricActivatorJobFactory {
+	MetricActivatorJob create(@Assisted AbstractMetric m,
+								@Assisted("daoID") Long daoID,
+								@Assisted Logger l,
+								@Assisted Class<? extends DAObject> daoType,
+								@Assisted("priority") long priority,
+								@Assisted boolean fastSync);
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/metricactivator/MetricActivatorModule.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/metricactivator/MetricActivatorModule.java
@@ -1,0 +1,16 @@
+package eu.sqooss.impl.service.metricactivator;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+
+import eu.sqooss.service.scheduler.Job;
+
+public class MetricActivatorModule extends AbstractModule {
+
+	@Override
+	protected void configure() {
+		install(new FactoryModuleBuilder().implement(Job.class,
+				MetricActivatorJob.class).build(MetricActivatorJobFactory.class));
+	}
+
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/rest/RestServiceModule.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/rest/RestServiceModule.java
@@ -1,0 +1,17 @@
+package eu.sqooss.impl.service.rest;
+
+import javax.servlet.http.HttpServlet;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+
+public class RestServiceModule extends AbstractModule 
+{
+	@Override
+	protected void configure() 
+	{
+		install(new FactoryModuleBuilder().implement(HttpServlet.class,
+				ResteasyServlet.class).build(ResteasyServletFactory.class));
+	}
+
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/rest/ResteasyServiceImpl.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/rest/ResteasyServiceImpl.java
@@ -39,10 +39,19 @@ import org.osgi.service.http.HttpService;
 import eu.sqooss.service.logging.Logger;
 import eu.sqooss.service.rest.RestService;
 
+import com.google.inject.Inject;
+
 public class ResteasyServiceImpl implements RestService {
 
 	private BundleContext bc;
     private Logger log ;
+    
+    private final ResteasyServletFactory reServletFactory;
+    
+    @Inject
+    public ResteasyServiceImpl(ResteasyServletFactory reServletFactory) {
+    	this.reServletFactory = reServletFactory;
+    }
    
 	@Override
 	public void addResource(Class<?> resource) {
@@ -65,7 +74,7 @@ public class ResteasyServiceImpl implements RestService {
 		params.put("resteasy.scan", "false");
 		params.put("javax.ws.rs.Application", "eu.sqooss.service.rest.RestServiceApp");
 
-		ResteasyServlet bridge = new ResteasyServlet();
+		ResteasyServlet bridge = reServletFactory.create();
 		try {
 			http.registerServlet("/api", bridge, params, null);
 		} catch (Exception e) {

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/rest/ResteasyServlet.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/rest/ResteasyServlet.java
@@ -37,19 +37,25 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
 
-import eu.sqooss.core.AlitheiaCore;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
 import eu.sqooss.service.db.DBService;
 
 public class ResteasyServlet extends HttpServletDispatcher {
 
 	private static final long serialVersionUID = 5968966644419029725L;
+	private DBService db;
+	
+	@Inject
+	public ResteasyServlet(Provider<DBService> dbsProvider) {
+		this.db = dbsProvider.get();
+	}	
 	
 	@Override
 	protected void service(HttpServletRequest httpServletRequest,
 	        HttpServletResponse httpServletResponse) throws ServletException,
 	        IOException {
-	    
-	    DBService db = AlitheiaCore.getInstance().getDBService();
 	    
 	    if (!db.isDBSessionActive())
 	        db.startDBSession();

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/rest/ResteasyServletFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/rest/ResteasyServletFactory.java
@@ -1,0 +1,6 @@
+package eu.sqooss.impl.service.rest;
+
+public interface ResteasyServletFactory 
+{
+	ResteasyServlet create();
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/scheduler/SchedulerServiceImpl.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/scheduler/SchedulerServiceImpl.java
@@ -44,6 +44,8 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import org.osgi.framework.BundleContext;
 
+import com.google.inject.Inject;
+
 import eu.sqooss.service.logging.Logger;
 import eu.sqooss.service.scheduler.Job;
 import eu.sqooss.service.scheduler.ResumePoint;
@@ -72,7 +74,12 @@ public class SchedulerServiceImpl implements Scheduler {
 
     private List<WorkerThread> myWorkerThreads = null;
     
-    public SchedulerServiceImpl() { }
+    private final WorkerThreadFactory workerThreadFactory;
+    
+    @Inject
+    public SchedulerServiceImpl(WorkerThreadFactory workerThreadFactory) {
+    	this.workerThreadFactory = workerThreadFactory;
+    }
 
     public void enqueue(Job job) throws SchedulerException {
         synchronized (this) {
@@ -198,7 +205,7 @@ public class SchedulerServiceImpl implements Scheduler {
             }
 
             for (int i = 0; i < n; ++i) {
-                WorkerThread t = new WorkerThreadImpl(this, i);
+                WorkerThread t = workerThreadFactory.create(this, i);
                 t.start();
                 myWorkerThreads.add(t);
                 stats.incWorkerThreads();
@@ -245,7 +252,7 @@ public class SchedulerServiceImpl implements Scheduler {
     }
 
     public void startOneShotWorkerThread() {
-        WorkerThread t = new WorkerThreadImpl(this, true);
+        WorkerThread t = workerThreadFactory.create(this, true);
         t.start();
     }
 

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/scheduler/SchedulerServiceModule.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/scheduler/SchedulerServiceModule.java
@@ -1,0 +1,16 @@
+package eu.sqooss.impl.service.scheduler;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+
+import eu.sqooss.service.scheduler.WorkerThread;
+
+public class SchedulerServiceModule extends AbstractModule {
+	
+	@Override
+	protected void configure() {
+		install(new FactoryModuleBuilder().
+				implement(WorkerThread.class, WorkerThreadImpl.class).
+				build(WorkerThreadFactory.class));
+	}
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/scheduler/WorkerThreadFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/scheduler/WorkerThreadFactory.java
@@ -1,0 +1,9 @@
+package eu.sqooss.impl.service.scheduler;
+
+import eu.sqooss.service.scheduler.Scheduler;
+import eu.sqooss.service.scheduler.WorkerThread;
+
+public interface WorkerThreadFactory {
+	WorkerThread create(Scheduler s, int n);
+	WorkerThread create(Scheduler s, boolean oneshot);
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/tds/TDSServiceImpl.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/tds/TDSServiceImpl.java
@@ -38,8 +38,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
 
-import eu.sqooss.core.AlitheiaCore;
-import eu.sqooss.core.AlitheiaCoreService;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
 import eu.sqooss.service.db.ClusterNode;
 import eu.sqooss.service.db.DBService;
 import eu.sqooss.service.db.StoredProject;
@@ -49,12 +50,17 @@ import eu.sqooss.service.tds.ProjectAccessor;
 import eu.sqooss.service.tds.TDSService;
 import eu.sqooss.service.util.URIUtills;
 
-public class TDSServiceImpl implements TDSService, AlitheiaCoreService {
+public class TDSServiceImpl implements TDSService {
     private Logger logger = null;
     private ConcurrentHashMap<Long, ProjectDataAccessorImpl> accessorPool;
     private ConcurrentHashMap<ProjectDataAccessorImpl, Integer> accessorClaims;
     
-    public TDSServiceImpl() {}
+    private final Provider<DBService> dbsProvider;
+    
+    @Inject
+    public TDSServiceImpl(Provider<DBService> dbsProvider) {
+    	this.dbsProvider = dbsProvider;
+    }
 
     // Interface methods
 
@@ -144,7 +150,7 @@ public class TDSServiceImpl implements TDSService, AlitheiaCoreService {
      */
     private void stuffer() {
         logger.info("TDS is now running the stuffer.");
-        DBService db = AlitheiaCore.getInstance().getDBService();
+        DBService db = dbsProvider.get();
         
         if (db != null && db.startDBSession()) {
             

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/AbstractView.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/AbstractView.java
@@ -46,35 +46,15 @@ import org.apache.velocity.VelocityContext;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
-import eu.sqooss.core.AlitheiaCore;
-import eu.sqooss.service.cluster.ClusterNodeService;
-import eu.sqooss.service.db.DBService;
-import eu.sqooss.service.logging.LogManager;
-import eu.sqooss.service.logging.Logger;
-import eu.sqooss.service.metricactivator.MetricActivator;
-import eu.sqooss.service.pa.PluginAdmin;
-import eu.sqooss.service.scheduler.Scheduler;
+import com.google.inject.Provider;
+
 import eu.sqooss.service.tds.TDSService;
-import eu.sqooss.service.updater.UpdaterService;
 
 public abstract class AbstractView {
     // Core components
-    protected static AlitheiaCore sobjCore = null;
     protected static ServiceReference srefCore = null;
 
-    // Critical logging components
-    protected static LogManager sobjLogManager = null;
-    protected static Logger sobjLogger = null;
-
-    // Service components
-    protected static DBService sobjDB = null;
-    protected static MetricActivator compMA = null;
-    protected static PluginAdmin sobjPA = null;
-    protected static Scheduler sobjSched = null;
-    protected static TDSService sobjTDS = null;
-    protected static UpdaterService sobjUpdater = null;
-    protected static ClusterNodeService sobjClusterNode = null;
-    protected static SecurityManager sobjSecurity = null;
+    private static TDSService tds;
 
     // Velocity stuff
     protected static VelocityContext vc = null;
@@ -102,64 +82,12 @@ public abstract class AbstractView {
      * @param bundlecontext the parent bundle's context
      * @param vc the Velocity instance's context
      */
-    public AbstractView(BundleContext bundlecontext, VelocityContext vc) {
+    public AbstractView(BundleContext bundlecontext, VelocityContext vcc,
+    		Provider<TDSService> tdsProvider) {
         // Keep the Velocity context instance
-        this.vc = vc;
+        vc = vcc;
         this.bc = bundlecontext;
-       
-        sobjCore = AlitheiaCore.getInstance();
-        
-        // Retrieve the instances of the core components
-        if (sobjCore != null) {
-            //Get the log manager's instance
-            sobjLogManager = sobjCore.getLogManager();
-            if (sobjLogManager != null) {
-                // Instantiate a dedicated logger 
-                sobjLogger = sobjLogManager.createLogger(
-                        Logger.NAME_SQOOSS_WEBADMIN);
-            }
-
-            // Get the database component's instance
-            sobjDB = sobjCore.getDBService();
-            if ((sobjDB == null) && (sobjLogger != null))
-                sobjLogger.debug("Could not get the database component's instance.");
-
-            // Get the plug-in admin's instance
-            sobjPA = sobjCore.getPluginAdmin();
-            if ((sobjPA == null) && (sobjLogger != null))
-                sobjLogger.debug("Could not get the plug-in admin's instance.");
-
-            // Get the scheduler's instance
-            sobjSched = sobjCore.getScheduler();
-            if ((sobjSched == null) && (sobjLogger != null))
-                sobjLogger.debug("Could not get the scheduler's instance.");
-
-            // Get the metric activator's instance
-            compMA = sobjCore.getMetricActivator();
-            if ((compMA == null) && (sobjLogger != null))
-                sobjLogger.debug("Could not get the metric activator's instance.");
-
-            // Get the TDS component's instance
-            sobjTDS = sobjCore.getTDSService();
-            if ((sobjTDS == null) && (sobjLogger != null))
-                sobjLogger.debug("Could not get the TDS component's instance.");
-
-            // Get the updater component's instance
-            sobjUpdater = sobjCore.getUpdater();
-            if ((sobjUpdater == null) && (sobjLogger != null))
-                sobjLogger.debug("Could not get the updater component's instance.");
-
-            // Get the ClusterNodeService component's instance
-            sobjClusterNode = sobjCore.getClusterNodeService();
-            if ((sobjClusterNode != null) && (sobjLogger != null))
-                sobjLogger.debug("Got the ClusterNodeService component's instance.");
-
-            
-            // Get the security manager's instance
-            sobjSecurity = sobjCore.getSecurityManager();
-            if ((sobjSecurity == null) && (sobjLogger != null))
-                sobjLogger.debug("Could not get the security manager's instance.");
-        }
+        tds = tdsProvider.get();
     }
 
     /**
@@ -535,7 +463,7 @@ public abstract class AbstractView {
      * provided string is not a URL.
      */
     protected static boolean checkTDSUrl (String url) {
-        return sobjTDS.isURLSupported(url);
+        return tds.isURLSupported(url);
     }
 }
 

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/AdminServletFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/AdminServletFactory.java
@@ -1,0 +1,12 @@
+package eu.sqooss.impl.service.webadmin;
+
+import org.apache.velocity.app.VelocityEngine;
+import org.osgi.framework.BundleContext;
+
+import eu.sqooss.service.logging.Logger;
+import eu.sqooss.service.webadmin.WebadminService;
+
+public interface AdminServletFactory {
+	AdminServlet create(BundleContext bc, WebadminService webadmin,
+            Logger logger, VelocityEngine ve);
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/PluginsView.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/PluginsView.java
@@ -43,18 +43,39 @@ import org.apache.velocity.VelocityContext;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.assistedinject.Assisted;
+
 import eu.sqooss.service.db.DAObject;
+import eu.sqooss.service.db.DBService;
 import eu.sqooss.service.db.Metric;
 import eu.sqooss.service.db.Plugin;
 import eu.sqooss.service.db.PluginConfiguration;
+import eu.sqooss.service.metricactivator.MetricActivator;
+import eu.sqooss.service.pa.PluginAdmin;
 import eu.sqooss.service.pa.PluginInfo;
 import eu.sqooss.service.pa.PluginInfo.ConfigurationType;
+import eu.sqooss.service.tds.TDSService;
 import eu.sqooss.service.util.StringUtils;
 
 public class PluginsView extends AbstractView{
 
-    public PluginsView(BundleContext bundlecontext, VelocityContext vc) {
-        super(bundlecontext, vc);
+	private static DBService dbs;
+	private static MetricActivator ma;
+	private static PluginAdmin pa;
+	
+	@Inject
+    public PluginsView(Provider<DBService> dbsProvider,
+    		Provider<MetricActivator> maProvider,
+    		Provider<PluginAdmin> paProvider,
+    		Provider<TDSService> tdsProvider,
+    		@Assisted BundleContext bundlecontext,
+    		@Assisted VelocityContext vc) {
+        super(bundlecontext, vc, tdsProvider);
+        dbs = dbsProvider.get();
+        ma = maProvider.get();
+        pa = paProvider.get();
     }
 
     /**
@@ -102,7 +123,7 @@ public class PluginsView extends AbstractView{
         PluginInfo selPI           = null;
 
         // Proceed only when at least one plug-in is registered
-        if (sobjPA.listPlugins().isEmpty()) {
+        if (pa.listPlugins().isEmpty()) {
             b.append(normalFieldset(
                     "All plug-ins",
                     null,
@@ -160,22 +181,22 @@ public class PluginsView extends AbstractView{
                     // Plug-in install request
                     // =======================================================
                     if (reqValAction.equals(actValInstall)) {
-                        if (sobjPA.installPlugin(reqValHashcode) == false) {
+                        if (pa.installPlugin(reqValHashcode) == false) {
                             e.append("Plug-in can not be installed!"
                                     + " Check log for details.");
                         }
                         // Persist the DB changes
                         else {
                             PluginInfo pInfo =
-                                sobjPA.getPluginInfo(reqValHashcode);
-                            sobjPA.pluginUpdated(sobjPA.getPlugin(pInfo));
+                                pa.getPluginInfo(reqValHashcode);
+                            pa.pluginUpdated(pa.getPlugin(pInfo));
                         }
                     }
                     // =======================================================
                     // Plug-in un-install request
                     // =======================================================
                     else if (reqValAction.equals(actValUninstall)) {
-                        if (sobjPA.uninstallPlugin(reqValHashcode) == false) {
+                        if (pa.uninstallPlugin(reqValHashcode) == false) {
                             e.append("Plug-in can not be uninstalled."
                                     + " Check log for details.");
                         } else {
@@ -185,7 +206,7 @@ public class PluginsView extends AbstractView{
                 }
                 // Retrieve the selected plug-in's info object
                 if (reqValHashcode != null) {
-                    selPI = sobjPA.getPluginInfo(reqValHashcode);
+                    selPI = pa.getPluginInfo(reqValHashcode);
                 }
                 // Plug-in info based actions
                 if ((selPI != null) && (selPI.installed)) {
@@ -193,7 +214,7 @@ public class PluginsView extends AbstractView{
                     // Plug-in synchronize (on all projects) request
                     // =======================================================
                     if (reqValAction.equals(actValSync)) {
-                        compMA.syncMetrics(sobjPA.getPlugin(selPI));
+                        ma.syncMetrics(pa.getPlugin(selPI));
                     }
                     // =======================================================
                     // Plug-in's configuration property removal
@@ -203,14 +224,14 @@ public class PluginsView extends AbstractView{
                                 reqValPropName, reqValPropType)) {
                             try {
                                 if (selPI.removeConfigEntry(
-                                        sobjDB,
+                                        dbs,
                                         reqValPropName,
                                         reqValPropType)) {
                                     // Update the Plug-in Admin's information
-                                    sobjPA.pluginUpdated(
-                                            sobjPA.getPlugin(selPI));
+                                    pa.pluginUpdated(
+                                            pa.getPlugin(selPI));
                                     // Reload the PluginInfo object
-                                    selPI = sobjPA.getPluginInfo(
+                                    selPI = pa.getPluginInfo(
                                             reqValHashcode);
                                 }
                                 else {
@@ -242,15 +263,15 @@ public class PluginsView extends AbstractView{
                         if (update) {
                             try {
                                 if (selPI.updateConfigEntry(
-                                        sobjDB,
+                                        dbs,
                                         reqValPropName,
                                         reqValPropValue)) {
                                     // Update the Plug-in Admin's information
-                                    sobjPA.pluginUpdated(
-                                            sobjPA.getPlugin(selPI));
+                                    pa.pluginUpdated(
+                                            pa.getPlugin(selPI));
                                     // Reload the PluginInfo object
                                     selPI =
-                                        sobjPA.getPluginInfo(reqValHashcode);
+                                        pa.getPluginInfo(reqValHashcode);
                                 }
                                 else {
                                     e.append("Property update"
@@ -266,17 +287,17 @@ public class PluginsView extends AbstractView{
                         else {
                             try {
                                 if (selPI.addConfigEntry(
-                                        sobjDB,
+                                        dbs,
                                         reqValPropName,
                                         reqValPropDescr,
                                         reqValPropType,
                                         reqValPropValue)) {
                                     // Update the Plug-in Admin's information
-                                    sobjPA.pluginUpdated(
-                                            sobjPA.getPlugin(selPI));
+                                    pa.pluginUpdated(
+                                            pa.getPlugin(selPI));
                                     // Reload the PluginInfo object
                                     selPI =
-                                        sobjPA.getPluginInfo(reqValHashcode);
+                                        pa.getPluginInfo(reqValHashcode);
                                 }
                                 else {
                                     e.append("Property creation"
@@ -594,7 +615,7 @@ public class PluginsView extends AbstractView{
                     b.append(sp(in++) + "<tbody>\n");
                     // Get the list of supported metrics
                     List<Metric> metrics =
-                        sobjPA.getPlugin(selPI).getAllSupportedMetrics();
+                        pa.getPlugin(selPI).getAllSupportedMetrics();
                     if ((metrics == null) || (metrics.isEmpty())) {
                         b.append(sp(in++) + "<tr>");
                         b.append(sp(in) + "<td colspan=\"4\" class=\"noattr\">"
@@ -731,7 +752,7 @@ public class PluginsView extends AbstractView{
                 b.append(sp(in) + "<fieldset>\n");
                 b.append(sp(++in) + "<legend>All plug-ins</legend>\n");
                 // Retrieve information for all registered metric plug-ins
-                Collection<PluginInfo> l = sobjPA.listPlugins();
+                Collection<PluginInfo> l = pa.listPlugins();
                 //------------------------------------------------------------
                 // Create the header row
                 //------------------------------------------------------------

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/PluginsViewFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/PluginsViewFactory.java
@@ -1,0 +1,8 @@
+package eu.sqooss.impl.service.webadmin;
+
+import org.apache.velocity.VelocityContext;
+import org.osgi.framework.BundleContext;
+
+public interface PluginsViewFactory {
+	PluginsView create(BundleContext bundlecontext, VelocityContext vc);
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/ProjectDeleteJobFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/ProjectDeleteJobFactory.java
@@ -1,0 +1,7 @@
+package eu.sqooss.impl.service.webadmin;
+
+import eu.sqooss.service.db.StoredProject;
+
+public interface ProjectDeleteJobFactory {
+	ProjectDeleteJob create(StoredProject sp);
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/ProjectsViewFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/ProjectsViewFactory.java
@@ -1,0 +1,8 @@
+package eu.sqooss.impl.service.webadmin;
+
+import org.apache.velocity.VelocityContext;
+import org.osgi.framework.BundleContext;
+
+public interface ProjectsViewFactory {
+	ProjectsView create(BundleContext bc, VelocityContext vc);
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/WebAdminRendererFactory.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/WebAdminRendererFactory.java
@@ -1,0 +1,8 @@
+package eu.sqooss.impl.service.webadmin;
+
+import org.apache.velocity.VelocityContext;
+import org.osgi.framework.BundleContext;
+
+public interface WebAdminRendererFactory {
+	WebAdminRenderer create(BundleContext bundlecontext, VelocityContext vc);
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/WebAdminServiceModule.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/WebAdminServiceModule.java
@@ -1,0 +1,30 @@
+package eu.sqooss.impl.service.webadmin;
+
+import javax.servlet.http.HttpServlet;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+
+import eu.sqooss.service.scheduler.Job;
+
+public class WebAdminServiceModule extends AbstractModule {
+
+	@Override
+	protected void configure() {
+		install(new FactoryModuleBuilder().implement(AbstractView.class,
+				ProjectsView.class).build(ProjectsViewFactory.class));
+		
+		install(new FactoryModuleBuilder().implement(AbstractView.class,
+				PluginsView.class).build(PluginsViewFactory.class));
+		
+		install(new FactoryModuleBuilder().implement(AbstractView.class,
+				WebAdminRenderer.class).build(WebAdminRendererFactory.class));
+		
+		install(new FactoryModuleBuilder().implement(HttpServlet.class,
+				AdminServlet.class).build(AdminServletFactory.class));
+		
+		install(new FactoryModuleBuilder().implement(Job.class,
+				ProjectDeleteJob.class).build(ProjectDeleteJobFactory.class));
+	}
+
+}

--- a/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/WebadminServiceImpl.java
+++ b/alitheia/core/src/main/java/eu/sqooss/impl/service/webadmin/WebadminServiceImpl.java
@@ -41,6 +41,8 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.http.HttpService;
 
+import com.google.inject.Inject;
+
 import eu.sqooss.service.logging.Logger;
 import eu.sqooss.service.webadmin.WebadminService;
 
@@ -71,9 +73,14 @@ public class WebadminServiceImpl implements WebadminService {
      */
     private String messageOfTheDay = null;
 
+    private final AdminServletFactory adminServletFactory;
+    
     private BundleContext bc;
 
-    public WebadminServiceImpl() { }
+    @Inject
+    public WebadminServiceImpl(AdminServletFactory adminServletFactory) { 
+    	this.adminServletFactory = adminServletFactory;
+    }
 
     /**
      * Retrieves the "message of the day" String
@@ -145,7 +152,7 @@ public class WebadminServiceImpl implements WebadminService {
             try {
                 sobjHTTPService.registerServlet(
                     "/",
-                    new AdminServlet(bc, this, logger, ve),
+                    adminServletFactory.create(bc, this, logger, ve),
                     new Hashtable(),
                     null);
             }

--- a/alitheia/core/src/test/java/eu/sqooss/test/core/CoreModuleTest.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/core/CoreModuleTest.java
@@ -1,0 +1,107 @@
+package eu.sqooss.test.core;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import eu.sqooss.core.CoreModule;
+import eu.sqooss.impl.service.fds.FDSServiceModule;
+import eu.sqooss.impl.service.metricactivator.MetricActivatorModule;
+import eu.sqooss.impl.service.rest.RestServiceModule;
+import eu.sqooss.impl.service.scheduler.SchedulerServiceModule;
+import eu.sqooss.impl.service.webadmin.WebAdminServiceModule;
+import eu.sqooss.service.admin.AdminService;
+import eu.sqooss.service.cluster.ClusterNodeService;
+import eu.sqooss.service.db.DBService;
+import eu.sqooss.service.fds.FDSService;
+import eu.sqooss.service.logging.LogManager;
+import eu.sqooss.service.metricactivator.MetricActivator;
+import eu.sqooss.service.pa.PluginAdmin;
+import eu.sqooss.service.scheduler.Scheduler;
+import eu.sqooss.service.tds.TDSService;
+import eu.sqooss.service.updater.UpdaterService;
+import eu.sqooss.service.webadmin.WebadminService;
+
+public class CoreModuleTest 
+{
+	private Injector injector;
+	
+	@Before
+	public void setUp()
+	{
+		injector = Guice.createInjector(	new CoreModule(), 
+													new SchedulerServiceModule(),
+													new RestServiceModule(),
+													new FDSServiceModule(),
+													new MetricActivatorModule(),
+													new WebAdminServiceModule());
+	}
+	
+	@Test
+	public void testAdminService() 
+	{		
+		injector.getProvider(AdminService.class);
+	}
+	
+	@Test
+	public void testClusterNodeService() 
+	{		
+		injector.getProvider(ClusterNodeService.class);
+	}
+	
+	@Test
+	public void testDBService() 
+	{		
+		injector.getProvider(DBService.class);
+	}
+	
+	@Test
+	public void testFDSService() 
+	{		
+		injector.getProvider(FDSService.class);
+	}
+	
+	@Test
+	public void LogManager() 
+	{		
+		injector.getProvider(LogManager.class);
+	}
+	
+	@Test
+	public void testMetricActivator() 
+	{
+		injector.getProvider(MetricActivator.class);
+	}
+	
+	@Test
+	public void testPAService() 
+	{
+		injector.getProvider(PluginAdmin.class);
+	}
+	
+	@Test
+	public void testScheduler() 
+	{
+		injector.getProvider(Scheduler.class);
+	}
+	
+	@Test
+	public void testTDSService() 
+	{
+		injector.getProvider(TDSService.class);
+	}
+	
+	@Test
+	public void testUpdaterService() 
+	{
+		injector.getProvider(UpdaterService.class);
+	}
+	
+	@Test
+	public void testWebadminService() 
+	{
+		injector.getProvider(WebadminService.class);
+	}
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/admin/AdminServiceImplTest.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/admin/AdminServiceImplTest.java
@@ -1,0 +1,135 @@
+package eu.sqooss.test.service.admin;
+
+import static org.junit.Assert.*;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import eu.sqooss.impl.service.admin.AdminServiceImpl;
+import eu.sqooss.impl.service.admin.AdminServiceImpl.ActionContainer;
+import eu.sqooss.service.admin.AdminAction;
+import eu.sqooss.service.admin.AdminAction.AdminActionStatus;
+import eu.sqooss.service.admin.actions.RunTimeInfo;
+import eu.sqooss.service.db.DBService;
+import eu.sqooss.test.testutils.TestUtils;
+
+public class AdminServiceImplTest {
+
+    static AdminServiceImpl impl;
+    static long failid;
+    static long successid;
+    static DBService dbs;
+
+    @BeforeClass
+    public static void setUp() {
+    	dbs = mock(DBService.class);
+        impl = new AdminServiceImpl(TestUtils.provide(dbs));
+    }
+
+    @Test
+    public void testAdminServiceImpl() {
+        assertNotNull(impl);
+    }
+
+    @Test
+    public void testRegisterAdminAction() {
+        RunTimeInfo rti = new RunTimeInfo();
+        impl.registerAdminAction(rti.mnemonic(), RunTimeInfo.class);
+        assertEquals(1, impl.getAdminActions().size());
+
+        FailingAction fa = new FailingAction();
+        impl.registerAdminAction(fa.mnemonic(), FailingAction.class);
+        assertEquals(2, impl.getAdminActions().size());
+
+        SucceedingAction su = new SucceedingAction();
+        impl.registerAdminAction(su.mnemonic(), SucceedingAction.class);
+        assertEquals(3, impl.getAdminActions().size());
+    }
+
+    @Test
+    public void testGetAdminActions() {
+        Set<AdminAction> actions = impl.getAdminActions();
+        for (AdminAction aa : actions)
+            assertNotNull (aa);
+    }
+    
+    @Test
+    public void testCreate() {
+        AdminAction fail = impl.create("blah");
+        assertNull(fail);
+
+        fail = impl.create("fail");
+        assertNotNull(fail);
+        ActionContainer ac = impl.liveactions().get(1L);
+        assertNotNull(ac);
+        assertEquals(-1, ac.end);
+
+        assertEquals(AdminActionStatus.CREATED, fail.status());
+        assertNull(fail.errors());
+        assertNull(fail.results());
+        failid = fail.id();
+    }
+    
+    @Test
+    public void testExecute() {
+        AdminAction success = impl.create("win");
+        assertNotNull(success);
+        impl.execute(success);
+        
+        assertNull(success.errors());
+        assertEquals("#win", success.results().get("1"));
+        assertEquals(AdminActionStatus.FINISHED, success.status());
+        successid = success.id();
+        
+        AdminAction fail = impl.create("fail");
+        assertNotNull(fail);
+        impl.execute(fail);
+        
+        assertNull(fail.results());
+        assertEquals("#fail", fail.errors().get("1"));
+        assertEquals(AdminActionStatus.ERROR, fail.status());
+        failid = fail.id();
+    }
+    
+    @Test
+    public void testShow() {
+        AdminAction aa = impl.show(failid);
+        assertNotNull(aa);
+        
+        aa = impl.show(successid);
+        assertNotNull(aa);
+    }
+    
+    @Test
+    public void testGC() {
+        try {
+            Thread.sleep (300);
+        } catch (InterruptedException e) {}
+        int collected = impl.gc(1);
+        
+        assertEquals(collected, 2);
+        
+        AdminAction aa = impl.show(failid);
+        assertNull(aa);
+    }
+    
+    @Test
+    public void testDBInject()
+    {
+    	DBService constructorDB = mock(DBService.class);
+    	AdminServiceImpl asi = new AdminServiceImpl(TestUtils.provide(constructorDB));
+
+        SucceedingAction su = new SucceedingAction();
+        impl.registerAdminAction(su.mnemonic(), SucceedingAction.class);
+        
+    	AdminAction a = asi.create("win");
+    	asi.execute(a);
+    	
+    	verify(constructorDB, times(2)).isDBSessionActive();
+    	verify(constructorDB).startDBSession();
+    }
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/admin/FailingAction.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/admin/FailingAction.java
@@ -1,0 +1,23 @@
+package eu.sqooss.test.service.admin;
+
+import eu.sqooss.service.admin.AdminActionBase;
+
+public class FailingAction extends AdminActionBase {
+
+    @Override
+    public String mnemonic() {
+        return "fail";
+    }
+
+    @Override
+    public String descr() {
+        return "An action that enjoys to fail itself";
+    }
+
+    @Override
+    public void execute() throws Exception {
+        super.execute();
+        error("1", "#fail");
+        throw new RuntimeException();
+    }
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/admin/SucceedingAction.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/admin/SucceedingAction.java
@@ -1,0 +1,23 @@
+package eu.sqooss.test.service.admin;
+
+import eu.sqooss.service.admin.AdminActionBase;
+
+public class SucceedingAction extends AdminActionBase {
+
+    @Override
+    public String mnemonic() {
+        return "win";
+    }
+
+    @Override
+    public String descr() {
+        return "An action that enjoys success";
+    }
+
+    @Override
+    public void execute() throws Exception {
+        super.execute();
+        result("1", "#win");
+        finished("");
+    }
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/fds/FDSServiceImplTest.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/fds/FDSServiceImplTest.java
@@ -1,0 +1,60 @@
+package eu.sqooss.test.service.fds;
+
+import static org.junit.Assert.*;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import eu.sqooss.impl.service.fds.FDSServiceImpl;
+import eu.sqooss.impl.service.fds.TimelineFactory;
+import eu.sqooss.service.fds.CheckoutException;
+import eu.sqooss.service.fds.OnDiskCheckout;
+import eu.sqooss.service.tds.ProjectAccessor;
+import eu.sqooss.service.tds.SCMAccessor;
+import eu.sqooss.service.tds.TDSService;
+import eu.sqooss.test.testutils.TestUtils;
+
+import static org.mockito.Mockito.*;
+
+public class FDSServiceImplTest 
+{
+
+	/*Ignored because the function that is used for testing (the only public method 
+	 * with a TDSProvider.get() currently either returns false if its first parameter
+	 * is not null or a NullPointerException is it is (due to a later cimpl.lock()
+	 * invocation. 	
+	 */
+	@Ignore
+	@Test
+	public void testDBInjection() 
+	{
+		TDSService tds = mock(TDSService.class);
+		FDSServiceImpl fds = new FDSServiceImpl(TestUtils.provide(tds), null, null, null);
+		
+		OnDiskCheckout odc = mock(OnDiskCheckout.class);
+		SCMAccessor scm = mock(SCMAccessor.class);
+		
+		when(tds.getAccessor(any(Long.class))).thenReturn((ProjectAccessor) scm);
+		
+		try {
+			fds.updateCheckout(odc, null);
+		} catch (CheckoutException e) {
+			fail("Test failed: " + e.getMessage());
+		}
+		
+		verify(tds).getAccessor(any(Long.class));
+	}
+	
+	@Test
+	public void testTimelineFactoryInjection()
+	{
+		TimelineFactory tlf = mock(TimelineFactory.class);
+		FDSServiceImpl fds = new FDSServiceImpl(null, null, null, tlf);
+		
+		fds.getTimeline(null);
+		
+		verify(tlf).create(null);
+	}
+	
+
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/metricactivator/MetricActivatorImplTest.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/metricactivator/MetricActivatorImplTest.java
@@ -1,0 +1,93 @@
+package eu.sqooss.test.service.metricactivator;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+
+import static org.mockito.Mockito.*;
+
+import eu.sqooss.impl.service.metricactivator.MetricActivatorImpl;
+import eu.sqooss.impl.service.metricactivator.MetricActivatorJobFactory;
+import eu.sqooss.service.abstractmetric.AbstractMetric;
+import eu.sqooss.service.abstractmetric.AlitheiaPlugin;
+import eu.sqooss.service.db.DAObject;
+import eu.sqooss.service.db.DBService;
+import eu.sqooss.service.db.StoredProject;
+import eu.sqooss.service.logging.Logger;
+import eu.sqooss.service.pa.PluginAdmin;
+import eu.sqooss.service.scheduler.Job;
+import eu.sqooss.service.scheduler.Scheduler;
+import eu.sqooss.service.scheduler.SchedulerException;
+import eu.sqooss.test.testutils.TestUtils;
+
+public class MetricActivatorImplTest 
+{
+	private PluginAdmin pa;
+	private DBService dbs;
+	private Scheduler sched;
+	private MetricActivatorJobFactory majf;
+	private MetricActivatorImpl ma;
+	
+	@Before
+	public void setUp()
+	{
+		pa = mock(PluginAdmin.class);
+		dbs = mock(DBService.class);
+		sched = mock(Scheduler.class);
+		majf = mock(MetricActivatorJobFactory.class);
+		
+		ma = new MetricActivatorImpl(null, TestUtils.provide(pa),
+				TestUtils.provide(dbs), TestUtils.provide(sched), majf);
+		
+		BundleContext bc = mock(BundleContext.class);
+		Logger l = mock(Logger.class);
+		
+		ma.setInitParams(bc, l);
+		ma.startUp();
+	}
+	
+	@Test
+	public void testPAInjection() 
+	{
+		ma.syncMetrics((StoredProject) null);
+		
+		verify(pa).listPlugins();
+	}
+	
+	@Test
+	public void testDBInjection()
+	{
+		ma.syncMetrics((AlitheiaPlugin) null);
+		
+		verify(dbs).doHQL("from StoredProject");
+	}
+
+	@Test
+	public void testSchedulerInjection()
+	{
+		DAObject dao = mock(DAObject.class);
+		AbstractMetric am = mock(AbstractMetric.class);
+		ma.runMetric(dao, am);
+		
+		try {
+			verify(sched).enqueue(any(Job.class));
+		} catch (SchedulerException e) {
+			fail("Test failed: " + e.getMessage());
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testMetricActivatorJobFactoryInjection() 
+	{
+		DAObject dao = mock(DAObject.class);
+		AbstractMetric am = mock(AbstractMetric.class);
+		ma.runMetric(dao, am);
+		
+		verify(majf).create(any(AbstractMetric.class), any(Long.class),
+				any(Logger.class), any(Class.class), any(long.class), anyBoolean());
+		
+	}
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/pa/PAServiceImplTest.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/pa/PAServiceImplTest.java
@@ -1,0 +1,52 @@
+package eu.sqooss.test.service.pa;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.osgi.framework.ServiceEvent;
+
+import static org.mockito.Mockito.*;
+
+import eu.sqooss.impl.service.pa.PAServiceImpl;
+import eu.sqooss.service.db.DBService;
+import eu.sqooss.service.scheduler.Job;
+import eu.sqooss.service.scheduler.Scheduler;
+import eu.sqooss.service.scheduler.SchedulerException;
+import eu.sqooss.test.testutils.TestUtils;
+
+public class PAServiceImplTest 
+{
+	@Test
+	public void testSchedulerInjection() 
+	{
+		Scheduler sched = mock(Scheduler.class);
+		try {
+			doNothing().when(sched).enqueue(any(Job.class));
+		} catch (SchedulerException e) {
+			fail("Test failed: " + e.getMessage());
+		}
+		PAServiceImpl pa = new PAServiceImpl(null, TestUtils.provide(sched));
+		pa.uninstallPlugin(new Long(1));
+		
+		try {
+			verify(sched).enqueue(any(Job.class));
+		} catch (SchedulerException e) {
+			fail("Test failed: " + e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testDBInjection() 
+	{
+		DBService dbs = mock(DBService.class);
+		
+		PAServiceImpl pa = new PAServiceImpl(TestUtils.provide(dbs), null);
+		
+		ServiceEvent se = mock(ServiceEvent.class);
+		pa.serviceChanged(se);
+		
+		verify(dbs).startDBSession();
+		verify(dbs).commitDBSession();		
+	}
+
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/rest/ResteasyServiceImplTest.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/rest/ResteasyServiceImplTest.java
@@ -1,0 +1,36 @@
+package eu.sqooss.test.service.rest;
+
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.HttpService;
+
+import static org.mockito.Mockito.*;
+
+import eu.sqooss.impl.service.rest.ResteasyServiceImpl;
+import eu.sqooss.impl.service.rest.ResteasyServletFactory;
+import eu.sqooss.service.logging.Logger;
+
+public class ResteasyServiceImplTest {
+
+	@Test
+	public void testFactoryInject() {
+		ResteasyServletFactory rasf = mock(ResteasyServletFactory.class);
+		ResteasyServiceImpl re = new ResteasyServiceImpl(rasf);
+		
+		BundleContext bc = mock(BundleContext.class);
+		ServiceReference sr = mock(ServiceReference.class);
+		when(bc.getServiceReference(
+				HttpService.class.getName())).thenReturn(sr);
+		
+		HttpService hs = mock(HttpService.class);
+		when(bc.getService(sr)).thenReturn(hs);
+		
+		Logger l = mock(Logger.class);
+		
+		re.setInitParams(bc, l);
+		re.addResource(eu.sqooss.rest.api.StoredProjectResource.class);
+		
+		verify(rasf).create();
+	}
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/scheduler/SchedulerTests.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/scheduler/SchedulerTests.java
@@ -4,8 +4,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.mockito.Mockito.*;
+
 import eu.sqooss.impl.service.scheduler.SchedulerServiceImpl;
+import eu.sqooss.impl.service.scheduler.WorkerThreadFactory;
+import eu.sqooss.service.scheduler.Scheduler;
 import eu.sqooss.service.scheduler.SchedulerException;
+import eu.sqooss.service.scheduler.WorkerThread;
 
 public class SchedulerTests {
     
@@ -13,7 +18,10 @@ public class SchedulerTests {
     
     @BeforeClass
     public static void setUp() {
-        sched = new SchedulerServiceImpl();
+    	WorkerThreadFactory wtf = mock(WorkerThreadFactory.class);
+    	WorkerThread wt = mock(WorkerThread.class);
+    	when(wtf.create(any(Scheduler.class), anyInt())).thenReturn(wt);
+        sched = new SchedulerServiceImpl(wtf);
         sched.startExecute(2);
     }
 

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/updater/UpdaterServiceImplTest.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/updater/UpdaterServiceImplTest.java
@@ -1,0 +1,69 @@
+package eu.sqooss.test.service.updater;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+
+import eu.sqooss.impl.service.updater.UpdaterServiceImpl;
+import eu.sqooss.service.db.DBService;
+import eu.sqooss.service.db.StoredProject;
+import eu.sqooss.service.logging.Logger;
+import eu.sqooss.service.tds.BTSAccessor;
+import eu.sqooss.service.tds.InvalidAccessorException;
+import eu.sqooss.service.tds.MailAccessor;
+import eu.sqooss.service.tds.ProjectAccessor;
+import eu.sqooss.service.tds.SCMAccessor;
+import eu.sqooss.service.tds.TDSService;
+import eu.sqooss.test.testutils.TestUtils;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+public class UpdaterServiceImplTest 
+{
+	private TDSService tds;
+	private DBService dbs;
+	private UpdaterServiceImpl us;
+	
+	
+	@Before
+	public void startUp()
+	{
+		tds = mock(TDSService.class);
+		dbs = mock(DBService.class);
+		us = new UpdaterServiceImpl(TestUtils.provide(dbs),
+				TestUtils.provide(tds), null, null);
+		
+		BundleContext bc = mock(BundleContext.class);
+		Logger l = mock(Logger.class);
+		
+		us.setInitParams(bc, l);
+		us.startUp();
+	}
+	
+	@Test
+	public void testTDSInjection() 
+	{		
+		StoredProject sp = mock(StoredProject.class);
+		Long expected = new Long(1);
+		when(sp.getId()).thenReturn(expected);
+		
+		ProjectAccessor pa = mock(ProjectAccessor.class);
+		SCMAccessor scm = mock(SCMAccessor.class);
+		BTSAccessor bts = mock(BTSAccessor.class);
+		MailAccessor mail = mock(MailAccessor.class);
+		
+		when(tds.getAccessor(any(Long.class))).thenReturn(pa);
+		try {
+			when(pa.getSCMAccessor()).thenReturn(scm);
+			when(pa.getBTSAccessor()).thenReturn(bts);
+			when(pa.getMailAccessor()).thenReturn(mail);
+		} catch(InvalidAccessorException e) {
+			fail("Test failed: " + e.getMessage());
+		}
+		
+		us.getUpdaters(sp);
+		
+		verify(tds).getAccessor(expected);
+	}
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/service/webadmin/WebadminServiceImplTest.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/service/webadmin/WebadminServiceImplTest.java
@@ -1,0 +1,40 @@
+package eu.sqooss.test.service.webadmin;
+
+import static org.junit.Assert.*;
+
+import org.apache.velocity.app.VelocityEngine;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.HttpService;
+
+import static org.mockito.Mockito.*;
+
+import eu.sqooss.impl.service.webadmin.AdminServletFactory;
+import eu.sqooss.impl.service.webadmin.WebadminServiceImpl;
+import eu.sqooss.service.logging.Logger;
+import eu.sqooss.service.webadmin.WebadminService;
+
+public class WebadminServiceImplTest {
+
+	@Test
+	public void testAdminServletFactoryInjection() {
+		AdminServletFactory asf = mock(AdminServletFactory.class);
+		WebadminServiceImpl was = new WebadminServiceImpl(asf);
+		BundleContext bc = mock(BundleContext.class);
+	
+		HttpService hs = mock(HttpService.class);
+		ServiceReference sr = mock(ServiceReference.class);
+		when(bc.getServiceReference(anyString())).thenReturn(sr);
+		when(bc.getService(any(ServiceReference.class))).thenReturn(hs);
+		
+		Logger l = mock(Logger.class);
+		
+		was.setInitParams(bc, l);
+		was.startUp();
+		
+		verify(asf).create(any(BundleContext.class), any(WebadminService.class),
+				any(Logger.class), any(VelocityEngine.class));
+	}
+
+}

--- a/alitheia/core/src/test/java/eu/sqooss/test/testutils/TestUtils.java
+++ b/alitheia/core/src/test/java/eu/sqooss/test/testutils/TestUtils.java
@@ -1,0 +1,15 @@
+package eu.sqooss.test.testutils;
+
+import static org.mockito.Mockito.*;
+import com.google.inject.Provider;
+
+public class TestUtils 
+{
+    public static<T> Provider<T> provide(T val) 
+    {
+        @SuppressWarnings("unchecked")
+        Provider<T> ret = (Provider<T>) mock(Provider.class);
+        when(ret.get()).thenReturn(val);
+        return ret;
+    }
+}


### PR DESCRIPTION
The changes in this pull request implement Dependency Injection for Alitheia using Guice.
The services that are initialised in the AlitheiaCore class are created by an injector provided by Guice. All references from the implementations of the services to the static AlitheiaCore instance are removed.

Not all references to AlitheiaCore have been removed, but can be when the Guice injector is used to create those classes as well.

Information as to why we have made certain choices for implementing Dependency Injection can be found in the report (SRE report 2). If there are any further questions, feel free to ask.
