### PR TITLE
Allow compilation on Java 8

### DIFF
--- a/metrics/findbugs/pom.xml
+++ b/metrics/findbugs/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>gr.aueb.metrics</groupId>
   <artifactId>findbugs</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.3-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>Findbugs plug-ins</name>
   <dependencies>
@@ -35,7 +35,7 @@
      <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.9.1</version>
+      <version>2.11.3</version>
     </dependency>
   </dependencies>
   <build>

--- a/parsers/pom.xml
+++ b/parsers/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr3-maven-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.5.2</version>
         <configuration>
           <sourceDirectory>src/main/antlr3</sourceDirectory>
         </configuration>


### PR DESCRIPTION
As at the moment many people will have Java 8, we should support Java 8 compilation.

I've compiled Alitheia on both Java 7 and 8 and with the update of FindBugs 0.0.3 and Antlr 3.5.2 it compiles again.

See also [https://github.com/antlr/antlr3/issues/151](https://github.com/antlr/antlr3/issues/151).
